### PR TITLE
Provide provision for global test parameter as global variable from command line

### DIFF
--- a/automacent-fwk-core/src/main/resources/log4j.properties
+++ b/automacent-fwk-core/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
 debugMode = INFO
 automacent.reportdir = report
-log4j.rootLogger=${debugMode}, stdout, rollingFile, rollingErrorFile
+log4j.rootLogger=${automacent.loglevel}, stdout, rollingFile, rollingErrorFile
 
 log.dir=${automacent.reportdir}/logs
 


### PR DESCRIPTION
Test defined custom variables specified by @parameters testNG annotation
can be provided to the testNG Test or XML file through the command line
by prepending them with -Dautomacent.global.**

example 

    @Parameters("email")
    @Test
    public void test1(String email)

    <suite name="test_suite">
        <test name-"test1">
            <classes>
                <class name="test.Test1">
            </classes>
        </test>
    </suite>

    mvn clean test -Dautomacent.global.email=test@test.com
