### PR TITLE
Add provision to log performance logs of chrome browser

### DIFF
--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/core/Driver.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/core/Driver.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -11,6 +12,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.automacent.fwk.enums.BrowserId;
@@ -319,16 +322,30 @@ public class Driver {
 							String.format("Expecting that chrome is already running at remote debugging address %s",
 									debuggerAddress));
 				} else {
+
+					LoggingPreferences logPrefs = new LoggingPreferences();
+					logPrefs.enable(LogType.PROFILER, Level.ALL);
+					logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
+					logPrefs.enable(LogType.BROWSER, Level.ALL);
+					logPrefs.enable(LogType.CLIENT, Level.ALL);
+					logPrefs.enable(LogType.DRIVER, Level.ALL);
+					logPrefs.enable(LogType.SERVER, Level.ALL);
+					chromeOptions.setCapability("goog:loggingPrefs", logPrefs);
+
 					chromeOptions.addArguments("--no-sandbox");
 					chromeOptions.addArguments("--disable-dev-shm-usage");
 					chromeOptions.addArguments("--safebrowsing-disable-download-protection");
 					Map<String, Object> chromePrefs = new HashMap<String, Object>();
 					chromePrefs.put("safebrowsing.enabled", "true");
+					chromePrefs.put("profile.default_content_setting_values.automatic_downloads", 1);
 					chromeOptions.setExperimentalOption("prefs", chromePrefs);
+					_logger.debug(String.format("Setting chrome capability %s", logPrefs.toJson()));
 					_logger.debug("Setting chrome switch --no-sandbox");
 					_logger.debug("Setting chrome switch --disable-dev-shm-usage");
 					_logger.debug("Setting chrome switch --no-sandbox");
 					_logger.debug("Setting chrome pref {safebrowsing.enabled : true}");
+					_logger.debug(
+							"Setting chrome pref {profile.default_content_setting_values.automatic_downloads : 1}");
 				}
 				webDriver = new ChromeDriver(chromeOptions);
 			} else if (driverManagerType.name().equals(DriverManagerType.FIREFOX.name())) {

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/ILauncherClient.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/ILauncherClient.java
@@ -86,4 +86,6 @@ public interface ILauncherClient {
 	 */
 	public void logEnd(String methodWithArguments, MethodType methodType, TestStatus testStatus, long duration,
 			Throwable t);
+	
+	void logPerformance();
 }

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
@@ -220,4 +220,12 @@ public class LauncherClientManager implements ILauncherClient {
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logEnd(methodWithArguments, methodType, testStatus, duration, t);
 	}
+
+	@Override
+	public void logPerformance() {
+		if (isEnabled)
+			for (ILauncherClient launcherClient : getLauncherClients())
+				launcherClient.logPerformance();
+	}
+
 }

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/reporting/ReportingTools.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/reporting/ReportingTools.java
@@ -352,14 +352,14 @@ public class ReportingTools {
 	 * 
 	 * @param logType {@link LogType}
 	 */
-	public static void captureSeleniumLogs1(String logType) {
+	public static Path captureSeleniumLogs(String logType) {
 		try {
 			if (BaseTest.getTestObject().getDriverManager().getActiveDriver().getWebDriver() != null) {
 				File parentDir = new File(System.getProperty("automacent.reportdir") + File.separator + "logs");
 				if (!parentDir.exists())
 					parentDir.mkdirs();
 
-				StandardOpenOption option = StandardOpenOption.APPEND;
+				StandardOpenOption option = StandardOpenOption.TRUNCATE_EXISTING;
 				File file = new File(parentDir.getAbsolutePath() + File.separator + "selenium_" + logType + ".log");
 				if (!file.exists())
 					option = StandardOpenOption.CREATE;
@@ -368,7 +368,7 @@ public class ReportingTools {
 				LogEntries logEntries = BaseTest.getTestObject().getDriverManager().getActiveDriver().getWebDriver()
 						.manage().logs().get(logType);
 				List<String> browserLogs = new ArrayList<>();
-				browserLogs.add("Iteration" + IterationManager.getManager().getIteration());
+				// browserLogs.add("Iteration" + IterationManager.getManager().getIteration());
 				for (LogEntry entry : logEntries)
 					browserLogs.add(String.format("%s %s %s %s", logType.toUpperCase(), entry.getTimestamp(),
 							entry.getLevel(), entry.getMessage()));
@@ -379,9 +379,11 @@ public class ReportingTools {
 							e);
 				}
 				_logger.info("Printing log entries for LogType - " + logType.toUpperCase());
+				return path;
 			}
 		} catch (Exception e) {
 			_logger.warn("Error while capturing Selenium Logs LogType - " + logType.toUpperCase(), e);
 		}
+		return null;
 	}
 }


### PR DESCRIPTION
- Enable browser performance logs for Chrome browser
- Add method `ReportingTools.captureSeleniumLogs` which will output the chrome performance logs to browser and return the path of the log file. The method returns null if the log operation failed
- Add methods in Launcher for logging performance