### PR TITLE
Remove all display parameters from context

### DIFF
--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
@@ -87,7 +87,7 @@ public abstract class BaseTest {
 	 * @param value Value of the parameter
 	 */
 	protected void addLocalTestParameter(String key, String value) {
-		addTestParameter(String.format("automacent.local.", key), value);
+		addTestParameter(String.format("automacent.local.%s", key), value);
 	}
 
 	/**

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
@@ -89,6 +89,17 @@ public abstract class BaseTest {
 	protected void addLocalTestParameter(String key, String value) {
 		addTestParameter(String.format("automacent.local.%s", key), value);
 	}
+	
+	/**
+	 * Add local test parameter prefixed with 'display.'. If the parameter with key
+	 * already exists, the value is overwritten
+	 * 
+	 * @param key   Name of the parameter
+	 * @param value Value of the parameter
+	 */
+	protected void addDisplayTestParameter(String key, String value) {
+		addLocalTestParameter(String.format("display.%s", key), value);
+	}
 
 	/**
 	 * Set up launcher clients for framework.Launcher clients are REST based

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
@@ -78,6 +78,17 @@ public abstract class BaseTest {
 	protected void appendTestParameter(String key, String value) {
 		BaseTest.getTestObject().appendTestParameter(key, value);
 	}
+	
+	/**
+	 * Add test parameter within the scope of current method. If the parameter with
+	 * key already exists, the value is overwritten
+	 * 
+	 * @param key   Name of the parameter
+	 * @param value Value of the parameter
+	 */
+	protected void addLocalTestParameter(String key, String value) {
+		addTestParameter(String.format("automacent.local.", key), value);
+	}
 
 	/**
 	 * Set up launcher clients for framework.Launcher clients are REST based

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -223,6 +223,11 @@ public class AutomacentListener extends TestListenerAdapter
 		if (!methodName.startsWith("automacentInternal")
 				&& BaseTest.getTestObject().getDriverManager().getActiveDriver() != null)
 			StepsAndPagesProcessor.processAnnotation(invokedMethod.getTestMethod().getInstance());
+		// Remove all display parameters from context
+		testContext.getCurrentXmlTest().getAllParameters().keySet().stream()
+			.filter(key -> key.startsWith("automacent.parameter.display.")).forEach(key -> {
+				testContext.getCurrentXmlTest().getAllParameters().remove(key);
+			});
 	}
 
 	/**

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -225,7 +225,7 @@ public class AutomacentListener extends TestListenerAdapter
 			StepsAndPagesProcessor.processAnnotation(invokedMethod.getTestMethod().getInstance());
 		// Remove all display parameters from context
 		testContext.getCurrentXmlTest().getAllParameters().keySet().stream()
-			.filter(key -> key.startsWith("automacent.parameter.display.")).forEach(key -> {
+			.filter(key -> key.startsWith("automacent.local.")).forEach(key -> {
 				testContext.getCurrentXmlTest().getAllParameters().remove(key);
 			});
 	}

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -224,10 +224,12 @@ public class AutomacentListener extends TestListenerAdapter
 				&& BaseTest.getTestObject().getDriverManager().getActiveDriver() != null)
 			StepsAndPagesProcessor.processAnnotation(invokedMethod.getTestMethod().getInstance());
 		// Remove all local parameters from context
-		testContext.getCurrentXmlTest().getAllParameters().keySet().stream()
-			.filter(key -> key.startsWith("automacent.local.")).forEach(key -> {
-				testContext.getCurrentXmlTest().getAllParameters().remove(key);
-			});
+		Map<String, String> localParameters = new ConcurrentHashMap<>();
+		localParameters.putAll(testContext.getCurrentXmlTest().getLocalParameters());
+		localParameters.keySet().stream().filter(key -> key.startsWith("automacent.local")).forEach(key -> {
+			localParameters.remove(key);
+		});
+		testContext.getCurrentXmlTest().setParameters(localParameters);
 	}
 
 	/**

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -223,7 +223,7 @@ public class AutomacentListener extends TestListenerAdapter
 		if (!methodName.startsWith("automacentInternal")
 				&& BaseTest.getTestObject().getDriverManager().getActiveDriver() != null)
 			StepsAndPagesProcessor.processAnnotation(invokedMethod.getTestMethod().getInstance());
-		// Remove all display parameters from context
+		// Remove all local parameters from context
 		testContext.getCurrentXmlTest().getAllParameters().keySet().stream()
 			.filter(key -> key.startsWith("automacent.local.")).forEach(key -> {
 				testContext.getCurrentXmlTest().getAllParameters().remove(key);

--- a/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -3,6 +3,7 @@ package com.automacent.fwk.listeners;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.testng.IExecutionListener;
 import org.testng.IInvokedMethod;


### PR DESCRIPTION
 In order to reduce the scope of specific parameters saved on TestNG context object, introducing this change.
This change will remove the targeted parameters (prefixed with '_automacent.parameter.display._') from context object so that those won't be shared with following methods in the Test.